### PR TITLE
comment out console.log(adjacent_6_8) - THAT is causing the LAGGY (mu…

### DIFF
--- a/re-des/insert.js
+++ b/re-des/insert.js
@@ -236,7 +236,7 @@ let shuffleIsValid = (tiles) => {
 
 
 
-    console.log(adjacent_6_8)
+//// console.log(adjacent_6_8)	// ?why log this? Because THIS is the reason for the LAGGY response (it logs it 50k+ times!)
 
     if (!adjacent_6_8) {
         validShuffle &&= passedAdjacencyTest(tiles, 6, 8)


### PR DESCRIPTION
…ltiple-seconds) response time -- since it logs it 50k+ times!

This is the only significant cause of lag; I verified (using console.timeEnd) that both passedResourceCheck and passedAdjacencyTest are fast enuf (once log line vanishes)